### PR TITLE
Improve web UI: dynamic keyboard, BPM, scales, inline status

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,12 +5,21 @@ This is a little tool that I'm developing for musical purposes.
 
 It could be used to make infinite and adaptative music for games, mainly for open world games.
 
-But, for now, it's only a prototype on Unity, hope to develop it a little more as soon as I can.
+There are two implementations in this repo:
+
+- **Web prototype** (`index.html`, `app.js`, `melody.ts`/`melody.js`,
+  `style.css`) — open `index.html` in a modern browser. No build step
+  required; `melody.js` is the pre-compiled output of `melody.ts`.
+- **Unity prototype** (`Assets/`) — the original playground with
+  chords, arpeggios, live player and MIDI integration.
 
 ## What happens next?
-I'm planning to work on:
+
+See [ROADMAP.md](./ROADMAP.md) for the current task list. The original
+long-term goals are still valid:
+
 - Procedural melody generation (OK!)
-- Multiple voices for melody (OK!)
+- Multiple voices for melody (OK! — in the Unity build)
 - Adaptative, parametrical design (in dev)
 - Friendly user interface (in dev)
 - Harmony

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,80 @@
+# Roadmap
+
+This document tracks the planned evolution of the web version of the
+Procedural Music Generator. The Unity prototype under `Assets/` is kept
+as a historical reference and a source of feature ideas.
+
+Tasks are grouped by horizon and roughly ordered by value / effort.
+
+## Just shipped
+
+- Dynamic piano keyboard covering C2–B5 (MIDI 36–83) so every default
+  parameter combination is visible.
+- BPM control wired into playback (previously hard-coded to 120).
+- Scale selector: chromatic, major, natural minor, pentatonic
+  major/minor, blues. Notes are quantized to the nearest scale degree
+  based on the configured tonic (`tone`).
+- Inline status messages replace the blocking `alert()` popups.
+
+## Near term (next)
+
+- [ ] **Rhythm / pauses**: the noise map already generates a `PAUSE`
+      track (`melody.js:147`); expose a control to translate it into
+      note durations or rests instead of discarding it.
+- [ ] **Note-length control**: expose "note value" (whole / half /
+      quarter / eighth) alongside BPM so tempo and subdivision are
+      independent.
+- [ ] **Stop playback button**: currently playback can only be aborted
+      by reloading. Maintain an array of scheduled oscillators and
+      cancel on click.
+- [ ] **Copy / share URL**: serialize current parameters into
+      `location.hash` so a seed + settings combo is shareable.
+- [ ] **Waveform selector**: sine only today — add square, sawtooth,
+      triangle via `oscillator.type`.
+- [ ] **Visualize the noise curve**: small canvas above the keyboard
+      showing the raw Perlin values that become notes.
+
+## Medium term
+
+- [ ] **Harmony track**: port `Chord` / `ChordDictionary` / `Arpeggio`
+      from `Assets/Scripts/` to TS and play chords under the melody.
+- [ ] **Bass line**: secondary voice with its own seed and lower
+      octave, following the harmony.
+- [ ] **Multiple voices**: generalize the generator to produce N voices
+      with shared harmonic context (the Unity version already
+      supports "multiple voices for melody").
+- [ ] **Preset library**: save / load named parameter sets in
+      `localStorage`.
+- [ ] **MIDI export**: download the generated melody as a `.mid` file
+      (roadmap item from the original README).
+
+## Long term
+
+- [ ] **Adaptive / parametric design**: expose parameters that can be
+      modulated over time (intensity, tension) so the music reacts to
+      external input — matches the original "adaptive music for open
+      world games" pitch.
+- [ ] **Game-engine-friendly packaging**: publish the core generator
+      as an npm package with a framework-agnostic API so it can be
+      embedded in web games and other tools.
+- [ ] **Real instrument samples**: swap the oscillator for sampled
+      instruments (piano, pads) via a small sample library.
+- [ ] **Documentation site** for use-as-asset purposes (also from the
+      original README).
+
+## Tech debt / housekeeping
+
+- [ ] Add a `package.json` with a `tsc` script so `melody.ts` is the
+      single source of truth and `melody.js` is generated.
+- [ ] Minimal test setup (node's built-in test runner is fine) for
+      `generateMelody` and `quantizeToScale`.
+- [ ] Lint / format config (ESLint + Prettier).
+- [ ] Decide the long-term status of the Unity project: keep, archive,
+      or extract useful logic and remove.
+
+## How to pick a task
+
+Prefer small, user-visible changes first (rhythm, stop button, share
+URL). Harmony and multi-voice are the biggest unlocks but require
+non-trivial design work — sketch the data model in an issue before
+coding.

--- a/app.js
+++ b/app.js
@@ -11,30 +11,88 @@ const perlinParamsControls = {
 
 const melodyParamsControls = {
     tone: document.getElementById('m-tone'),
-    octave: document.getElementById('m-octave')
+    octave: document.getElementById('m-octave'),
+    scale: document.getElementById('m-scale')
 };
 
-// Buttons
+const playbackParamsControls = {
+    bpm: document.getElementById('p-bpm')
+};
+
+// Buttons and status
 const generateMelodyBtn = document.getElementById('generate-melody-btn');
 const playMelodyBtn = document.getElementById('play-melody-btn');
+const statusMessage = document.getElementById('status-message');
 
-// Disable Play Melody button initially
+function setStatus(text, kind) {
+    if (!statusMessage) return;
+    statusMessage.textContent = text || '';
+    statusMessage.className = 'status-message' + (kind ? ' status-' + kind : '');
+}
+
 if (playMelodyBtn) {
     playMelodyBtn.disabled = true;
 }
 
-// Update persistance value display
 if (perlinParamsControls.persistance && perlinParamsControls.persistanceVal) {
     perlinParamsControls.persistance.addEventListener('input', () => {
         perlinParamsControls.persistanceVal.textContent = perlinParamsControls.persistance.value;
     });
 }
 
-// Function to get current parameter values from UI
+// Scale definitions: semitone offsets from the tonic
+const SCALES = {
+    'chromatic': null,
+    'major': [0, 2, 4, 5, 7, 9, 11],
+    'minor': [0, 2, 3, 5, 7, 8, 10],
+    'pentatonic-major': [0, 2, 4, 7, 9],
+    'pentatonic-minor': [0, 3, 5, 7, 10],
+    'blues': [0, 3, 5, 6, 7, 10]
+};
+
+// Piano keyboard: MIDI 36 (C2) to 83 (B5)
+const PIANO_START_MIDI = 36;
+const PIANO_END_MIDI = 83;
+const NOTE_NAMES = ['C', 'C#', 'D', 'D#', 'E', 'F', 'F#', 'G', 'G#', 'A', 'A#', 'B'];
+const noteToKeyId = {};
+
+function midiToNoteName(midi) {
+    const pitchClass = ((midi % 12) + 12) % 12;
+    const octave = Math.floor(midi / 12) - 1;
+    return NOTE_NAMES[pitchClass] + octave;
+}
+
+function renderPiano() {
+    const piano = document.getElementById('piano');
+    if (!piano) return;
+    piano.innerHTML = '';
+    for (let midi = PIANO_START_MIDI; midi <= PIANO_END_MIDI; midi++) {
+        const pitchClass = ((midi % 12) + 12) % 12;
+        const octave = Math.floor(midi / 12) - 1;
+        const name = NOTE_NAMES[pitchClass];
+        const isBlack = name.includes('#');
+        const keyId = 'key-' + name.replace('#', 's') + octave;
+        const el = document.createElement('div');
+        el.className = 'key ' + (isBlack ? 'black' : 'white');
+        el.dataset.note = name + octave;
+        el.id = keyId;
+        if (!isBlack) {
+            const label = document.createElement('span');
+            label.className = 'key-label';
+            label.textContent = name + octave;
+            el.appendChild(label);
+        }
+        piano.appendChild(el);
+        noteToKeyId[midi] = keyId;
+    }
+}
+
+renderPiano();
+
 function getPerlinParameters() {
     return {
         length: parseInt(perlinParamsControls.length.value),
-        width: 1, // Fixed for single melody line
+        width: 1,
         seed: parseInt(perlinParamsControls.seed.value),
         octaves: parseInt(perlinParamsControls.octaves.value),
         persistance: parseFloat(perlinParamsControls.persistance.value),
@@ -44,62 +102,54 @@ function getPerlinParameters() {
 }
 
 function getMelodyParameters() {
+    const scaleKey = melodyParamsControls.scale ? melodyParamsControls.scale.value : 'chromatic';
     return {
         tone: parseInt(melodyParamsControls.tone.value),
         octave: parseInt(melodyParamsControls.octave.value),
-        scale: null // Scale UI not implemented in this step
+        scale: SCALES[scaleKey] || null
     };
 }
 
-let currentMelody = []; // To store the generated melody
+function getBpm() {
+    const raw = parseInt(playbackParamsControls.bpm.value);
+    if (isNaN(raw) || raw <= 0) return 120;
+    return raw;
+}
+
+let currentMelody = [];
 
 if (generateMelodyBtn) {
     generateMelodyBtn.addEventListener('click', () => {
         const pParams = getPerlinParameters();
         const mParams = getMelodyParameters();
 
-        console.log("Perlin Params from UI:", pParams);
-        console.log("Melody Params from UI:", mParams);
-
         if (typeof generateMelody === 'function') {
             try {
                 currentMelody = generateMelody(pParams, mParams);
-                console.log("Generated Melody:", currentMelody);
-                alert(`Melody generated with ${currentMelody.length} notes!`);
-
+                setStatus(`Melody generated with ${currentMelody.length} notes.`, 'ok');
                 if (playMelodyBtn) {
                     playMelodyBtn.disabled = (!currentMelody || currentMelody.length === 0);
                 }
             } catch (error) {
                 console.error("Error generating melody:", error);
-                alert("Error generating melody. Check console for details.");
-                currentMelody = []; // Clear melody on error
-                if (playMelodyBtn) {
-                    playMelodyBtn.disabled = true;
-                }
+                setStatus('Error generating melody. Check console.', 'error');
+                currentMelody = [];
+                if (playMelodyBtn) playMelodyBtn.disabled = true;
             }
         } else {
-            console.error("generateMelody function not found. Ensure melody.js is loaded and correct.");
-            alert("Melody generation script not loaded correctly.");
-            currentMelody = []; // Clear melody if function not found
-            if (playMelodyBtn) {
-                playMelodyBtn.disabled = true;
-            }
+            console.error("generateMelody function not found.");
+            setStatus('Melody generation script not loaded correctly.', 'error');
+            currentMelody = [];
+            if (playMelodyBtn) playMelodyBtn.disabled = true;
         }
     });
-} else {
-    console.error("Generate Melody button not found.");
 }
 
-// Web Audio API and Playback
 let audioContext;
-let tempo = 120; // BPM
-let noteDuration = 60 / tempo; // Duration of a quarter note in seconds
 
 function initAudioContext() {
     if (!audioContext) {
         audioContext = new (window.AudioContext || window.webkitAudioContext)();
-        console.log("AudioContext initialized.");
     }
 }
 
@@ -107,24 +157,8 @@ function midiToFreq(midiNote) {
     return 440 * Math.pow(2, (midiNote - 69) / 12);
 }
 
-function mapNoteToMidi(noteValue) {
-    return noteValue;
-}
-
-const noteToKeyId = {
-    60: 'key-C4', 61: 'key-Cs4', 62: 'key-D4', 63: 'key-Ds4', 64: 'key-E4',
-    65: 'key-F4', 66: 'key-Fs4', 67: 'key-G4', 68: 'key-Gs4', 69: 'key-A4',
-    70: 'key-As4', 71: 'key-B4',
-    72: 'key-C5', 73: 'key-Cs5', 74: 'key-D5', 75: 'key-Ds5', 76: 'key-E5',
-    77: 'key-F5', 78: 'key-Fs5', 79: 'key-G5', 80: 'key-Gs5', 81: 'key-A5',
-    82: 'key-As5', 83: 'key-B5'
-};
-
 function playNote(midiNoteNumber, startTime, duration) {
-    if (!audioContext) {
-        console.warn("AudioContext not initialized. Cannot play note.");
-        return;
-    }
+    if (!audioContext) return;
     const oscillator = audioContext.createOscillator();
     const gainNode = audioContext.createGain();
     oscillator.connect(gainNode);
@@ -135,8 +169,8 @@ function playNote(midiNoteNumber, startTime, duration) {
     const attackTime = 0.05;
     const decayTime = 0.1;
     const sustainLevel = 0.7;
-    const releaseTime = 0.2;
-    const notePlayDuration = duration - releaseTime > 0 ? duration - releaseTime : 0.01;
+    const releaseTime = Math.min(0.2, duration * 0.4);
+    const notePlayDuration = Math.max(duration - releaseTime, 0.01);
 
     gainNode.gain.setValueAtTime(0, startTime);
     gainNode.gain.linearRampToValueAtTime(1.0, startTime + attackTime);
@@ -150,10 +184,10 @@ function playNote(midiNoteNumber, startTime, duration) {
     if (keyId) {
         const keyElement = document.getElementById(keyId);
         if (keyElement) {
-            const highlightDelay = (startTime - audioContext.currentTime) > 0 ? (startTime - audioContext.currentTime) * 1000 : 0;
-            const removeHighlightDelay = (startTime - audioContext.currentTime + duration) > 0 ? (startTime - audioContext.currentTime + duration) * 1000 : duration * 1000;
-            setTimeout(() => keyElement.classList.add('active'), highlightDelay);
-            setTimeout(() => keyElement.classList.remove('active'), removeHighlightDelay);
+            const nowOffset = Math.max(0, (startTime - audioContext.currentTime) * 1000);
+            const endOffset = Math.max(0, (startTime - audioContext.currentTime + duration) * 1000);
+            setTimeout(() => keyElement.classList.add('active'), nowOffset);
+            setTimeout(() => keyElement.classList.remove('active'), endOffset);
         }
     }
 }
@@ -162,35 +196,31 @@ if (playMelodyBtn) {
     playMelodyBtn.addEventListener('click', () => {
         initAudioContext();
         if (!currentMelody || currentMelody.length === 0) {
-            alert("No melody generated yet, or melody is empty. Click 'Generate Melody' first.");
+            setStatus("No melody generated yet. Click 'Generate Melody' first.", 'warn');
             return;
         }
         if (!audioContext) {
-            alert("AudioContext could not be initialized.");
+            setStatus('AudioContext could not be initialized.', 'error');
             return;
         }
 
-        if (playMelodyBtn) playMelodyBtn.disabled = true;
+        const noteDuration = 60 / getBpm();
+        playMelodyBtn.disabled = true;
         if (generateMelodyBtn) generateMelodyBtn.disabled = true;
+        setStatus('Playing…', 'ok');
 
-        console.log("Playing melody:", currentMelody);
         const melodyStartTime = audioContext.currentTime + 0.1;
         for (let i = 0; i < currentMelody.length; i++) {
-            const noteValue = currentMelody[i];
-            const midiNote = mapNoteToMidi(noteValue);
+            const midiNote = currentMelody[i];
             const noteStartTime = melodyStartTime + i * noteDuration;
             playNote(midiNote, noteStartTime, noteDuration);
         }
 
         const totalMelodyDuration = currentMelody.length * noteDuration;
         setTimeout(() => {
-            if (playMelodyBtn) playMelodyBtn.disabled = false;
+            playMelodyBtn.disabled = false;
             if (generateMelodyBtn) generateMelodyBtn.disabled = false;
-            console.log("Playback finished. Controls re-enabled.");
+            setStatus('Playback finished.', 'ok');
         }, (totalMelodyDuration + 0.5) * 1000);
     });
-} else {
-    console.error("Play Melody button not found.");
 }
-
-console.log('app.js fully loaded with UI refinements and playback logic.');

--- a/index.html
+++ b/index.html
@@ -48,44 +48,35 @@
             </div>
             <div>
                 <label for="m-octave">Base Octave:</label>
-                <input type="number" id="m-octave" value="3" min="0" max="7">
+                <input type="number" id="m-octave" value="4" min="2" max="5">
             </div>
-            <!-- 'scale' parameter is more complex (array of numbers), so we'll omit a UI control for it in this iteration for simplicity. -->
+            <div>
+                <label for="m-scale">Scale:</label>
+                <select id="m-scale">
+                    <option value="chromatic" selected>Chromatic</option>
+                    <option value="major">Major</option>
+                    <option value="minor">Natural Minor</option>
+                    <option value="pentatonic-major">Pentatonic Major</option>
+                    <option value="pentatonic-minor">Pentatonic Minor</option>
+                    <option value="blues">Blues</option>
+                </select>
+            </div>
+        </div>
+        <div id="playback-params">
+            <h3>Playback Parameters</h3>
+            <div>
+                <label for="p-bpm">BPM:</label>
+                <input type="number" id="p-bpm" value="120" min="40" max="240">
+            </div>
         </div>
         <button id="generate-melody-btn">Generate Melody</button>
+        <div id="status-message" class="status-message" aria-live="polite"></div>
     </div>
 
     <div class="output-container">
         <h2>Generated Melody</h2>
         <div id="piano-keyboard">
-            <div class="piano">
-                <!-- Octave 4 -->
-                <div class="key white" data-note="C4" id="key-C4"><span class="key-label">C4</span></div>
-                <div class="key black" data-note="C#4" id="key-Cs4"></div>
-                <div class="key white" data-note="D4" id="key-D4"><span class="key-label">D4</span></div>
-                <div class="key black" data-note="D#4" id="key-Ds4"></div>
-                <div class="key white" data-note="E4" id="key-E4"><span class="key-label">E4</span></div>
-                <div class="key white" data-note="F4" id="key-F4"><span class="key-label">F4</span></div>
-                <div class="key black" data-note="F#4" id="key-Fs4"></div>
-                <div class="key white" data-note="G4" id="key-G4"><span class="key-label">G4</span></div>
-                <div class="key black" data-note="G#4" id="key-Gs4"></div>
-                <div class="key white" data-note="A4" id="key-A4"><span class="key-label">A4</span></div>
-                <div class="key black" data-note="A#4" id="key-As4"></div>
-                <div class="key white" data-note="B4" id="key-B4"><span class="key-label">B4</span></div>
-                <!-- Octave 5 -->
-                <div class="key white" data-note="C5" id="key-C5"><span class="key-label">C5</span></div>
-                <div class="key black" data-note="C#5" id="key-Cs5"></div>
-                <div class="key white" data-note="D5" id="key-D5"><span class="key-label">D5</span></div>
-                <div class="key black" data-note="D#5" id="key-Ds5"></div>
-                <div class="key white" data-note="E5" id="key-E5"><span class="key-label">E5</span></div>
-                <div class="key white" data-note="F5" id="key-F5"><span class="key-label">F5</span></div>
-                <div class="key black" data-note="F#5" id="key-Fs5"></div>
-                <div class="key white" data-note="G5" id="key-G5"><span class="key-label">G5</span></div>
-                <div class="key black" data-note="G#5" id="key-Gs5"></div>
-                <div class="key white" data-note="A5" id="key-A5"><span class="key-label">A5</span></div>
-                <div class="key black" data-note="A#5" id="key-As5"></div>
-                <div class="key white" data-note="B5" id="key-B5"><span class="key-label">B5</span></div>
-            </div>
+            <div class="piano" id="piano"></div>
         </div>
         <button id="play-melody-btn">Play Melody</button>
     </div>

--- a/melody.js
+++ b/melody.js
@@ -155,6 +155,24 @@ range, octaves, persistance, lacunarity, offset) {
     }
     return result;
 }
+function quantizeToScale(midiNote, tonicPitchClass, scale) {
+    if (!scale || scale.length === 0) {
+        return midiNote;
+    }
+    const degreeFromTonic = midiNote - tonicPitchClass;
+    const octaveOffset = Math.floor(degreeFromTonic / 12);
+    const semitoneInOctave = ((degreeFromTonic % 12) + 12) % 12;
+    let best = scale[0];
+    let bestDistance = Math.abs(semitoneInOctave - scale[0]);
+    for (let i = 1; i < scale.length; i++) {
+        const distance = Math.abs(semitoneInOctave - scale[i]);
+        if (distance < bestDistance) {
+            best = scale[i];
+            bestDistance = distance;
+        }
+    }
+    return tonicPitchClass + octaveOffset * 12 + best;
+}
 function generateMelody(perlinParameters, melodyParameters) {
     const currentMelodyParameters = melodyParameters !== null && melodyParameters !== void 0 ? melodyParameters : {
         tone: 0,
@@ -167,10 +185,10 @@ function generateMelody(perlinParameters, melodyParameters) {
     const noiseMap = generateHeights(width, length, seed, noiseScale, range, octaves, persistance, lacunarity, offset);
     const melody = new Array(noiseMap.length);
     for (let i = 0; i < melody.length; i++) {
-        melody[i] =
-            noiseMap[i][NOTE] +
-                currentMelodyParameters.octave * 12 +
-                currentMelodyParameters.tone;
+        const raw = noiseMap[i][NOTE] +
+            currentMelodyParameters.octave * 12 +
+            currentMelodyParameters.tone;
+        melody[i] = quantizeToScale(raw, currentMelodyParameters.tone, currentMelodyParameters.scale);
     }
     return melody;
 }

--- a/melody.ts
+++ b/melody.ts
@@ -218,6 +218,29 @@ function generateHeights(
   return result;
 }
 
+function quantizeToScale(
+  midiNote: number,
+  tonicPitchClass: number,
+  scale: number[] | null
+): number {
+  if (!scale || scale.length === 0) {
+    return midiNote;
+  }
+  const degreeFromTonic = midiNote - tonicPitchClass;
+  const octaveOffset = Math.floor(degreeFromTonic / 12);
+  const semitoneInOctave = ((degreeFromTonic % 12) + 12) % 12;
+  let best = scale[0];
+  let bestDistance = Math.abs(semitoneInOctave - scale[0]);
+  for (let i = 1; i < scale.length; i++) {
+    const distance = Math.abs(semitoneInOctave - scale[i]);
+    if (distance < bestDistance) {
+      best = scale[i];
+      bestDistance = distance;
+    }
+  }
+  return tonicPitchClass + octaveOffset * 12 + best;
+}
+
 function generateMelody(
   perlinParameters: PerlinParameters,
   melodyParameters?: MelodyParameters
@@ -256,10 +279,15 @@ function generateMelody(
   const melody: number[] = new Array(noiseMap.length);
 
   for (let i = 0; i < melody.length; i++) {
-    melody[i] =
+    const raw =
       noiseMap[i][NOTE] +
       currentMelodyParameters.octave * 12 +
       currentMelodyParameters.tone;
+    melody[i] = quantizeToScale(
+      raw,
+      currentMelodyParameters.tone,
+      currentMelodyParameters.scale
+    );
   }
 
   return melody;

--- a/style.css
+++ b/style.css
@@ -20,12 +20,12 @@ h1 {
 
 .controls-container, .output-container {
     background-color: #ffffff;
-    padding: 25px; /* Slightly more padding */
-    border-radius: 12px; /* More rounded corners */
-    box-shadow: 0 4px 12px rgba(0,0,0,0.1); /* Softer shadow */
+    padding: 25px;
+    border-radius: 12px;
+    box-shadow: 0 4px 12px rgba(0,0,0,0.1);
     margin-bottom: 25px;
     width: 90%;
-    max-width: 750px;
+    max-width: 900px;
 }
 
 .controls-container div, .output-container div {
@@ -58,6 +58,24 @@ h1 {
     font-weight: bold;
 }
 
+.controls-container select {
+    padding: 8px;
+    border-radius: 6px;
+    border: 1px solid #dcdcdc;
+    background-color: #fff;
+    min-width: 180px;
+}
+
+.status-message {
+    margin-top: 12px;
+    min-height: 1.2em;
+    font-size: 0.95em;
+    color: #555;
+}
+.status-message.status-ok { color: #27ae60; }
+.status-message.status-warn { color: #e67e22; }
+.status-message.status-error { color: #c0392b; }
+
 
 button {
     padding: 12px 20px; /* Bigger buttons */
@@ -85,9 +103,10 @@ button:disabled {
     justify-content: center;
     padding: 20px 0;
     margin-bottom: 20px;
-    background-color: #f8f9fa; /* Light background for the keyboard area */
+    background-color: #f8f9fa;
     border-radius: 8px;
     box-shadow: inset 0 0 10px rgba(0,0,0,0.05);
+    overflow-x: auto;
 }
 
 .piano {
@@ -100,61 +119,35 @@ button:disabled {
 }
 
 .key.white {
-    background-color: #fdfdfd; /* Slightly off-white */
-    width: 42px; /* Slightly wider */
-    height: 190px; /* Slightly taller */
-    border: 1px solid #ccc; /* Lighter border for white keys */
+    background-color: #fdfdfd;
+    width: 32px;
+    height: 170px;
+    border: 1px solid #ccc;
     box-shadow: 0 2px 3px rgba(0,0,0,0.1);
+    position: relative;
 }
 
 .key.black {
-    background-color: #2c3e50; /* Consistent dark color */
-    width: 26px;
-    height: 125px;
+    background-color: #2c3e50;
+    width: 20px;
+    height: 110px;
     border: 1px solid #222;
     box-shadow: 0 2px 3px rgba(0,0,0,0.2);
-    z-index: 2; /* Ensure black keys are on top - was already there but good to confirm */
-    margin-left: -13px; /* Half of black key width if centered, adjust as needed */
-    margin-right: -13px;
+    z-index: 2;
+    margin-left: -10px;
+    margin-right: -10px;
+    position: relative;
 }
-/* Correcting black key positioning based on new white key width (42px) and black key width (26px)
-   Half of black key width is 13px.
-   So, they should be offset by -13px relative to the edge of the previous white key.
-*/
-.key[data-note="C#4"], .key[data-note="C#5"] { margin-left: calc(-26px/2 + (42px - 26px)/2); } /* Effectively -13px from center of where it would be */
-.key[data-note="D#4"], .key[data-note="D#5"] { margin-left: calc(-26px/2 + (42px - 26px)/2); }
-.key[data-note="F#4"], .key[data-note="F#5"] { margin-left: calc(-26px/2 + (42px - 26px)/2); }
-.key[data-note="G#4"], .key[data-note="G#5"] { margin-left: calc(-26px/2 + (42px - 26px)/2); }
-.key[data-note="A#4"], .key[data-note="A#5"] { margin-left: calc(-26px/2 + (42px - 26px)/2); }
-/* The above calc is a bit off. Simpler to just use -13px to position their left edge from the previous white key's center point of the black key */
-/* A more standard way for overlap: */
-.key.black {
-    /* ... other properties ... */
-    margin-left: -14px; /* Adjust this for precise overlap based on key widths & borders */
-    margin-right: -14px; /* Should be same as margin-left to keep spacing consistent if key was not there */
-}
-/* Remove individual margin-left for black keys if using the general one above, unless specific adjustments are needed */
-/* For example, if white keys are 42px, black keys 26px. Black key should start at 42 - (26/2) = 42 - 13 = 29px from left edge of white key.
-   Or, if it's relative to the previous key: white_key_width - black_key_width/2
-   The provided CSS had negative margins for black keys which is a common technique.
-   If white key is 40px, black is 24px. margin-left: -12px places the black key starting at 28px on the white key.
-   New: white 42px, black 26px. margin-left: -13px places black key starting at 29px.
-   This looks fine. I will revert to the original simpler negative margins from the prompt as they are generally effective.
-*/
-.key[data-note="C#4"], .key[data-note="C#5"] { margin-left: -13px; }
-.key[data-note="D#4"], .key[data-note="D#5"] { margin-left: -13px; }
-.key[data-note="F#4"], .key[data-note="F#5"] { margin-left: -13px; }
-.key[data-note="G#4"], .key[data-note="G#5"] { margin-left: -13px; }
-.key[data-note="A#4"], .key[data-note="A#5"] { margin-left: -13px; }
 
 
 .key-label {
-    color: #7f8c8d; /* Softer label color */
-    font-size: 0.75em;
-    position: absolute; /* Copied from prompt */
-    bottom: 10px;     /* Copied from prompt */
-    left: 50%;        /* Copied from prompt */
-    transform: translateX(-50%); /* Copied from prompt */
+    color: #7f8c8d;
+    font-size: 0.65em;
+    position: absolute;
+    bottom: 6px;
+    left: 50%;
+    transform: translateX(-50%);
+    pointer-events: none;
 }
 
 .key.active {


### PR DESCRIPTION
## Summary
- Render the piano dynamically across **MIDI 36–83 (C2–B5)** so the default parameter combo (`octave=3/4`, `range=24`) is actually visible on the keyboard. Previously only the last note in the default range landed on a key.
- Add a **BPM control** wired into playback (was hard-coded to 120 in `app.js`).
- Add a **scale selector** (chromatic / major / natural minor / pentatonic major/minor / blues) and quantize generated notes via a new `quantizeToScale` helper in both `melody.ts` and `melody.js`. The `scale` parameter was accepted by the API but never used.
- Replace blocking `alert()` popups with an inline `#status-message` area.
- Tighten piano CSS (32px white / 20px black keys, horizontal scroll on small viewports) to fit 4 octaves comfortably.

## Planning
Added [`ROADMAP.md`](./ROADMAP.md) with near-/medium-/long-term tasks and tech-debt notes so we can pick up work incrementally. Highlights for next iterations: rhythm (use the already-generated `PAUSE` track), stop button, share URL, waveform selector, then harmony/bass/MIDI export.

## Test plan
- [ ] Open `index.html` in a browser, click **Generate Melody**, then **Play Melody**.
- [ ] Confirm keys highlight during playback (defaults now land on keyboard).
- [ ] Change BPM (40–240) and re-play; note duration should scale accordingly.
- [ ] Switch scale to **Major** with seed=1 — all played pitch classes should be in `{0,2,4,5,7,9,11}` relative to the tonic.
- [ ] Try an invalid state (e.g. length=0) and verify the status message is inline, not a popup.
- [ ] `node melody.js` still runs the self-test block without errors.

https://claude.ai/code/session_012vrBSH6GDDsGVMMTE8YKEf